### PR TITLE
Ersetzt Regime mit Reglement

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
 			<p>
 			Schon die <q>Bewertung der Wahrscheinlichkeit</q> einer Gefährdung reicht zukünftig aus, um das Redaktions- und andere anerkannte Berufsgeheimnisse auch ohne direkte
 			Beschlagnahme zu unterminieren. Auch ein vergleichbarer Rechtsweg, mit welchem sich die <abbr>ORF</abbr>-Redaktion damals gegen den Bruch des Redaktionsgeheimnisses gewehrt hat,
-			stünde den Betroffenen nach dem vorgeschlagenen Regime nicht zur Verfügung, sofern sie vom Einschreiten der Behörden überhaupt erfahren.
+			stünde den Betroffenen nach dem vorgeschlagenen Reglement nicht zur Verfügung, sofern sie vom Einschreiten der Behörden überhaupt erfahren.
 		</p>
 
 		<h2>Beispiel 2: Gefährderdatenbank</h2>


### PR DESCRIPTION
Ich vermute Autokorrektur hat aus Reglement Regime gemacht - Satz Neu:

Auch ein vergleichbarer Rechtsweg, mit welchem sich die ORF-Redaktion damals gegen den Bruch des Redaktionsgeheimnisses gewehrt hat,    stünde den Betroffenen nach dem vorgeschlagenen Reglement nicht zur Verfügung
