### PR TITLE
chrome-compatible modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Petition gegen das geplante Staatsschutzgesetz" />
     <meta property="og:url" content="https://www.staatsschutz.at" />
     <meta property="og:description" content="Kein neuer Inlandsgeheimdienst in Österreich!" />
-    <link href="./css/bootstrap/bootstrap336.min.css" rel="stylesheet" />
+    <link rel="stylesheet" type="text/css" href="./css/bootstrap/bootstrap336.min.css" />
     <link rel="stylesheet" type="text/css" href="./css/basic.css" />
     <link rel="stylesheet" type="text/css" href="./css/various.css" />
     <link rel="stylesheet" type="text/css" href="./css/slider.css" />
@@ -304,48 +304,22 @@
                     </article>
                 </div>
                 
-                <article class="indent paper shadow" id="privacyns">
-                    <h2>Datenschutzerkl&auml;rung</h2>
-                    <p>Die persönlichen Daten der Unterzeichner und Unterzeichnerinnen dieser Petition werden in einer Datenbank abgelegt und am Ende der Kampagne an die Parlamentsdirektion des Österreichischen Parlaments übergeben. Mit der optionalen Anmeldung zu unserem Newsletter werden Ihre Daten in unserer Newsletter-Software verarbeitet. Siehe dazu unsere verständlichen <a href="https://www.akvorrat.at/kontakt#datenschutz">Datenschutzbestimmungen</a>.</p>
-                    <p>Wenn Sie angeben, mit Ihrer Unterstützung öffentlich gelistet werden zu wollen, geben Sie uns das Einverständnis, Ihre Daten für Kampagnen-Zwecke zu verarbeiten und öffentlich zugänglich zu machen. Ihre E-Mail Adresse und Ihr vollständiger Nachname sind von dieser Veröffentlichung jedoch ausgeschlossen.</p>
-                    <p>Darüber hinaus werden die Daten nicht an Dritte weitergegeben und auch für keine anderen Zwecke verwendet. Wenn die Petition abgeschlossen ist, werden alle personenbezogenen Daten gelöscht.</p>
-                </article>
-
-                <article class="indent paper shadow">
-                    <h2 id="glosar">Glosar</h2>
-                    <dl>
-                        <dt><abbr>PStSG</abbr></dt>
-                        <dd>Polizeiliches Staatsschutzgesetz</dd>
-                        <dt><abbr>SPG</abbr></dt>
-                        <dd>Sicherheitspolizeigesetz</dd>
-                        <dt><abbr>StPO</abbr></dt>
-                        <dd>Strafprozessordnung</dd>
-                        <dt><abbr>BVT</abbr></dt>
-                        <dd>Bundesamt für Verfassungsschutz und Terrorismusbekämpfung</dd>
-                        <dt><abbr>LV</abbr></dt>
-                        <dd>Landesämter für Verfassungsschutz</dd>
-                    </dl>
-                </article>
-
-                <article class="indent paper shadow">
-                    <h2 id="dokumente">Dokumente</h2>
-                    <dl>
-                        <dt><img src="./img/icons/pdf.png" alt="PDF" /></dt>
-                        <dd><a href="http://akvorrat.at/sites/default/files/PSTSG_Kritik_short.pdf">Kritik Kurzfassung</a> (2 Seiten, 110 KB)</dd>
-                        <dt><img src="./img/icons/pdf.png" alt="PDF" /></dt>
-                        <dd><a href="http://akvorrat.at/sites/default/files/akvorrat_print-handout-PStSG.pdf">Handout zum ersten Entwurf des Gesetzes</a> (4 Seiten, 110 KB)</dd>
-                        <dt><img src="./img/icons/pdf.png" alt="PDF" /></dt>
-                        <dd><a href="http://akvorrat.at/sites/default/files/AKVorrat_PStSG_Stellungnahme_RV.pdf">Stellungnahme AKVorrat zum 2. Entwurf (Regierungsvorlage)</a> (40 Seiten, 810 KB)</dd>
-                        <dt><img src="./img/icons/pdf.png" alt="PDF" /></dt>
-                        <dd><a href="https://www.akvorrat.at/sites/default/files/AKVorrat-Stellungnahme-Polizeiliches%20Staatsschutzgesetz%20-%20PStSG_Entwurf_BM%20I_Stellungnahme.pdf">Stellungnahme AKVorrat zum 1. Gesetzesentwurf</a> (79 Seiten, 3,63 MB)</dd>
-                        <dt><img src="./img/icons/www.png" alt="Link" /></dt>
-                        <dd><a href="http://www.parlament.gv.at/PAKT/VHG/XXV/ME/ME_00110/index.shtml">alle Stellungnahmen zum 1. Gesetzesentwurf</a> (39 Stellungnahmen, Parlamentshomepage)</dd>
-                        <dt><img src="./img/icons/pdf.png" alt="PDF" /></dt>
-                        <dd><a href="./docs/PSTSG-Vergleich%20RV-Innenausschuss-2015-11-30.pdf">Änderungsanträge der Regierungsparteien für den Innenausschuss am 1. Dezember 2015</a> (32 Seiten, 658 KB)</dd>
-                        <dt></dt>
-                        <dd><a href="./img/sharables.zip">Banner zum Teilen</a> (ZIP, 931 KB)</dd>
-                    </dl>
-                </article>
+                <noscript>
+                    <article class="indent paper shadow" id="privacyns">
+                        <h2>Datenschutzerkl&auml;rung</h2>
+                        <p>Die persönlichen Daten der Unterzeichner und Unterzeichnerinnen dieser Petition werden in einer Datenbank abgelegt und am Ende der Kampagne an die Parlamentsdirektion des Österreichischen Parlaments übergeben. Mit der optionalen Anmeldung zu unserem Newsletter werden Ihre Daten in unserer Newsletter-Software verarbeitet. Siehe dazu unsere verständlichen <a href="https://www.akvorrat.at/kontakt#datenschutz">Datenschutzbestimmungen</a>.</p>
+                        <p>Wenn Sie angeben, mit Ihrer Unterstützung öffentlich gelistet werden zu wollen, geben Sie uns das Einverständnis, Ihre Daten für Kampagnen-Zwecke zu verarbeiten und öffentlich zugänglich zu machen. Ihre E-Mail Adresse und Ihr vollständiger Nachname sind von dieser Veröffentlichung jedoch ausgeschlossen.</p>
+                        <p>Darüber hinaus werden die Daten nicht an Dritte weitergegeben und auch für keine anderen Zwecke verwendet. Wenn die Petition abgeschlossen ist, werden alle personenbezogenen Daten gelöscht.</p>
+                    </article>
+                </noscript>
+                
+                <form class="form-inline center indent">
+                    <div class="form-group">
+                        <button type="button" class="btn btn-default btn-lg" data-toggle="modal" data-target="#privacyModal">Datenschutzerkl&auml;rung</button>
+                        <button type="button" class="btn btn-default btn-lg" data-toggle="modal" data-target="#glossaryModal">Glossar</button>
+                        <button type="button" class="btn btn-default btn-lg" data-toggle="modal" data-target="#downloadsModal">Downloads</button>
+                    </div>
+                </form>
                 
                 <div class="center"><a href="https://akvorrat.at/kontakt">Kontakt / Impressum / Presse</a></div>
             </section>
@@ -377,7 +351,7 @@
     <!--END body footer-->
 
     <!--START privacyModal-->
-    <details class="modal fade" id="privacyModal" tabindex="-1" role="dialog" aria-labelledby="privacyModal">
+    <div class="modal fade" id="privacyModal" tabindex="-1" role="dialog" aria-labelledby="privacyModal">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
@@ -394,11 +368,11 @@
                 </div>
             </div>
         </div>
-    </details>
+    </div>
     <!--END privacyModal-->
     
     <!--START glossaryModal-->
-    <details class="modal fade" id="glossaryModal" tabindex="-1" role="dialog" aria-labelledby="glossaryModal">
+    <div class="modal fade" id="glossaryModal" tabindex="-1" role="dialog" aria-labelledby="glossaryModal">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
@@ -424,11 +398,11 @@
                 </div>
             </div>
         </div>
-    </details>
+    </div>
     <!--END glossaryModal-->
     
     <!--START downloadsModal-->
-    <details class="modal fade" id="downloadsModal" tabindex="-1" role="dialog" aria-labelledby="downloadsModal">
+    <div class="modal fade" id="downloadsModal" tabindex="-1" role="dialog" aria-labelledby="downloadsModal">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
@@ -458,7 +432,7 @@
                 </div>
             </div>
         </div>
-    </details>
+    </div>
     <!--END downloadsModal-->
     
     <!-- Piwik -->

--- a/js/slider.js
+++ b/js/slider.js
@@ -14,6 +14,15 @@ var timeout = 3000;
 
 $(function () {
     findElements();
+    
+    var hash = window.location.hash.substring(1);
+    if (hash == "dokumente") {
+        $("#downloadsModal").modal("show");
+    } else if (hash == "glosar") {
+        $("#glossaryModal").modal("show");
+    } else if (hash == "privacy") {
+        $("#privacyModal").modal("show");
+    }
 })
 
 function htmlColToArray(xml, tagName) {


### PR DESCRIPTION
- Chrome was not able to open HTML5 standardised semantic detail boxes.
- Open modal when URI anchor is set.
